### PR TITLE
ISSUE #10465 Fix - Sentinel Central Workbook now counting incidents correctly

### DIFF
--- a/Workbooks/Sentinel_Central.json
+++ b/Workbooks/Sentinel_Central.json
@@ -108,7 +108,7 @@
                   "type": 4,
                   "isRequired": true,
                   "value": {
-                    "durationMs": 86400000
+                    "durationMs": 604800000
                   },
                   "typeSettings": {
                     "selectableValues": [


### PR DESCRIPTION
Fixed ISSUE #10465  where incidents were not being counted correctly.

   Required items, please complete
   
   Change(s):
   - Changed KQL Queries to include an `arg_max()` to prevent incidents from being counted multiple times in Workbooks\Sentinel_Central.json
   - Updated Change Log in Workbooks\Sentinel_Central.json

   Reason for Change(s):
   - See ISSUE #10465 

   Version Updated:
   - Yes
   - Updated Changelog

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes